### PR TITLE
Implement the behavior for converting to lexicoids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/michaelherold/lexicoid-ruby/tree/main)
+
+### Added
+
+- Converting timestamps in the form of `Integer`s, `Float`s, `Time`s, `DateTime`s, and anything responding to `#to_date`, including `ActiveSupport::TimeWithZone` via `Lexicoid.from`.
+- Generating the lexicoid for the current moment with `Lexicoid.now`.
+- Converting timestamps with the `Kernel#Lexicoid` method, with optional exception squelching via `Lexicoid(Time.now, exception: false)`.

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :development do
 end
 
 group :test do
+  gem "activesupport", "~> 7.0"
   gem "minitest"
   gem "minitest-reporters"
   gem "rack-test"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,12 +6,20 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.0.4.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     ansi (1.5.0)
     ast (2.4.2)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
+    concurrent-ruby (1.2.2)
     docile (1.4.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
     inch (0.8.0)
       pry
       sparkr (>= 0.2.0)
@@ -77,6 +85,8 @@ GEM
       tins (~> 1.0)
     tins (1.32.1)
       sync
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
     webrick (1.7.0)
     yard (0.9.28)
@@ -86,6 +96,7 @@ PLATFORMS
   x86_64-darwin-21
 
 DEPENDENCIES
+  activesupport (~> 7.0)
   bundler (>= 2)
   inch
   lexicoid!

--- a/lib/core_ext/kernel.rb
+++ b/lib/core_ext/kernel.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# The `Kernel` module is included by class `Object`, so its methods are available in every Ruby object.
+#
+# @see https://ruby-doc.org/current/Kernel.html
+module Kernel
+  private
+
+  # Returns a lexicographically sortable friendly ID for a timestamp
+  #
+  # @api public
+  # @since 0.1.0
+  # @!visibility public
+  #
+  # @example Converts a post's created-at timestamp to a friendly ID
+  #   Post = Struct.new(:created_at, keyword_init: true)
+  #   post = Post.new(created_at: Time.parse("2023-03-19 14:33:01.80251 -0500"))
+  #
+  #   Lexicoid(post.created_at) #=> "gkfqavc"
+  #
+  # @param object [ActiveSupport::TimeWithZone, DateTime, Float, Integer, Time, #to_time]
+  #   the object to convert into a lexicographically sorting friendly ID
+  # @param exception [Boolean] raises an ArgumentError when the argument is
+  #   improper and this is true, otherwise an improper argument leads to an empty string
+  # @return [String] the friendly ID
+  # @raise [ArgumentError] when the object is not a timestamp-like one
+  def Lexicoid(object, exception: true)
+    Lexicoid.from(object)
+  rescue ArgumentError
+    raise if exception
+    ""
+  end
+end

--- a/lib/lexicoid.rb
+++ b/lib/lexicoid.rb
@@ -27,4 +27,166 @@ require_relative "lexicoid/version"
 # [1]: https://brandur.org/fragments/base32-slugs
 # [2]: https://datatracker.ietf.org/doc/html/rfc4648
 module Lexicoid
+  # The Time instance representing the time at the beginning of the Unix epoch
+  #
+  # @api private
+  # @private
+  EPOCH = Time.at(0).utc.freeze
+
+  # The alphabet for encoding lexicographic base32 IDs
+  #
+  # @api private
+  # @private
+  LEXICOGRAPHIC_BASE32 = "234567abcdefghijklmnopqrstuvwxyz"
+
+  # Converts a timestamp into a lexicographically sortable, friendly ID
+  #
+  # @api public
+  # @since 0.1.0
+  #
+  # @example Generate a lexicoid from a DateTime
+  #   Lexicoid.from DateTime.parse("2023-03-19T21:19:50-05:00")
+  #
+  # @example Generate a lexicoid from a Float timestamp
+  #   Lexicoid.from 2_147_483_647.0
+  #
+  # @example Generate a lexicoid from an Integer timestamp
+  #   Lexicoid.from 946_684_799
+  #
+  # @example Generate a lexicoid from a Time
+  #   Lexicoid.from Time.parse("2023-03-19 15:06:14.48414 -0500")
+  #
+  # @example Generate a lexicoid in a Rails application
+  #   Lexicoid.from 2.weeks.ago
+  #
+  # @param number_or_time [ActiveSupport::TimeWithZone, DateTime, Float, Integer, Time, #to_time]
+  #   the object to convert into a lexicographically sorting friendly ID
+  # @return [String] the friendly ID
+  # @raise [ArgumentError] when the object is unsuitable for conversion
+  def self.from(number_or_time)
+    number = maybe_coerce_time(number_or_time)
+    bytes = bytes_from_number(number)
+    buffer = encode(bytes)
+
+    buffer.join
+  end
+
+  # Generates a lexicographically sortable, friendly ID from the current time
+  #
+  # @api public
+  # @since 0.1.0
+  #
+  # @example Generate a friendly ID for the current moment
+  #   Lexicoid.now
+  #
+  # @return [String] the friendly ID
+  def self.now
+    from Time.now
+  end
+
+  # Extracts the bytes from a number in big endian order
+  #
+  # @api private
+  # @private
+  #
+  # @param number [Integer] the number to extract bytes from
+  # @return [Array<Integer>] the bytes from the number as integers in big endian
+  #   order
+  private_class_method def self.bytes_from_number(number)
+    [].tap do |bytes|
+      bytes.unshift(0) and next if number.zero?
+
+      while number.positive?
+        bytes.unshift(number & 0xFF)
+        number >>= 8
+      end
+    end
+  end
+
+  # Encodes a byte array into a lexicographically sortable array of characters
+  #
+  # @api private
+  # @private
+  #
+  # @param bytes [Array<Integer>] the bytes to encode, in big endian order
+  # @return [Array<String>] the bytes encoded to the lexicographic base32 alphabet
+  private_class_method def self.encode(bytes)
+    result = Array.new((bytes.length * 8 + 4) / 5, 0)
+    offset = 0
+
+    while bytes.length.positive?
+      length = bytes.length
+      buffer =
+        case length
+        when 1, 2 then Array.new(bytes.length * 2, 0)
+        when 3, 4 then Array.new(bytes.length * 2 - 1, 0)
+        else Array.new(8, 0)
+        end
+
+      if length > 4
+        buffer[7] = bytes[4] & 0x1F
+        buffer[6] = bytes[4] >> 5
+      end
+
+      if length >= 4
+        buffer[6] |= (bytes[3] << 3) & 0x1F
+        buffer[5] = (bytes[3] >> 2) & 0x1F
+        buffer[4] = bytes[3] >> 7
+      end
+
+      if length >= 3
+        buffer[4] |= (bytes[2] << 1) & 0x1F
+        buffer[3] = (bytes[2] >> 4) & 0x1F
+      end
+
+      if length >= 2
+        buffer[3] |= (bytes[1] << 4) & 0x1F
+        buffer[2] = (bytes[1] >> 1) & 0x1F
+        buffer[1] = (bytes[1] >> 6) & 0x1F
+      end
+
+      if length >= 1
+        buffer[1] |= (bytes[0] << 2) & 0x1F
+        buffer[0] = bytes[0] >> 3
+      end
+
+      buffer.each_with_index do |byte, i|
+        result[i + offset] = LEXICOGRAPHIC_BASE32[byte & 31]
+      end
+
+      break if bytes.length < 5
+
+      bytes = bytes[5..]
+      offset += 8
+    end
+
+    result
+  end
+
+  # Validates and coerces an argument for suitability for conversion
+  #
+  # @api private
+  # @private
+  #
+  # @param object [Object] the object to validate and coerce
+  # @return [Integer] the object converted into an integer timestamp
+  # @raise [ArgumentError] when the object is unsuitable for conversion
+  private_class_method def self.maybe_coerce_time(object)
+    if object.is_a?(Integer) || object.is_a?(Float)
+      raise ArgumentError, "#{object} must be non-negative" if object.negative?
+      object.to_i
+    elsif object.is_a?(Time)
+      raise ArgumentError, "#{object.iso8601} must be after #{EPOCH.iso8601}" unless EPOCH <= object
+      object.to_i
+    elsif object.respond_to?(:to_time)
+      maybe_coerce_time object.to_time
+    else
+      raise(
+        ArgumentError,
+        "#{object.inspect} must be one of Integer, Float, Time, or respond to `#to_time'"
+      )
+    end
+  end
 end
+
+require_relative "core_ext/kernel"

--- a/test/core_ext/test_kernel.rb
+++ b/test/core_ext/test_kernel.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestKernel < Minitest::Test
+  def test_kernel_method_can_squelch_errors
+    assert_raises(ArgumentError) { Lexicoid("oops") }
+    assert_equal "", Lexicoid("oops", exception: false)
+  end
+
+  def test_kernel_method_is_private_on_objects
+    assert_raises(NoMethodError) { Object.new.Lexicoid(Time.now) }
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,8 +16,19 @@ require "minitest/autorun"
 require "minitest/reporters"
 require "pry"
 require "pry-byebug"
+require "time"
+
+require "active_support"
+require "active_support/core_ext/integer/time"
+require "active_support/core_ext/time"
+require "active_support/time_with_zone"
 
 require "lexicoid"
+
+Time.zone = "UTC"
+
+# Remove this when bumping to ActiveSupport 7.1
+ActiveSupport::TimeWithZone.singleton_class.remove_method(:name)
 
 Minitest::Reporters.use! [
   Minitest::Reporters::DefaultReporter.new(

--- a/test/test_lexicoid.rb
+++ b/test/test_lexicoid.rb
@@ -3,4 +3,116 @@
 require "test_helper"
 
 class TestLexicoid < Minitest::Test
+  def test_that_it_has_a_version_number
+    refute_nil ::Lexicoid::VERSION
+  end
+
+  def test_from_with_integers
+    assert_equal "22", Lexicoid.from(0)               # Thu Jan 01 1970 00:00:00 -0000
+    assert_equal "gk", Lexicoid.from(100)             # Thu Jan 01 1970 00:01:40 -0000
+    assert_equal "6wc2", Lexicoid.from(10000)         # Thu Jan 01 1970 02:46:40 -0000
+    assert_equal "2ykm2", Lexicoid.from(500000)       # Tue Jan 06 1970 18:53:20 -0000
+    assert_equal "5bse2", Lexicoid.from(1700000)      # Tue Jan 20 1970 16:13:20 -0000
+    assert_equal "2apny22", Lexicoid.from(28000000)   # Sat Nov 21 1970 01:46:40 -0000
+    assert_equal "6567f22", Lexicoid.from(550000000)  # Sat Jun 06 1987 17:46:40 -0000
+    assert_equal "flllz22", Lexicoid.from(1550000000) # Tue Feb 12 2019 19:33:20 -0000
+    assert_equal "gehebv2", Lexicoid.from(1654301676) # Sat Jun 04 2022 00:14:36 -0000
+    assert_equal "gei4p52", Lexicoid.from(1654401676) # Sun Jun 05 2022 04:01:16 -0000
+    assert_equal "gj7x3v2", Lexicoid.from(1674301676) # Sat Jan 21 2023 11:47:56 -0000
+    assert_equal "gj7x3vc", Lexicoid.from(1674301677) # Sat Jan 21 2023 11:47:57 -0000
+
+    assert_equal "26222222", Lexicoid.from(2**32)          # Sun Feb 07 2106 06:28:16 -0000
+    assert_equal "jzzzzzzzzzzzy", Lexicoid.from(2**63 - 1) # Sun Dec 04 292277026596 15:30:07 -0000
+  end
+
+  def test_from_with_floats
+    assert_equal "22", Lexicoid.from(0.0)               # Thu Jan 01 1970 00:00:00 -0000
+    assert_equal "gk", Lexicoid.from(100.0)             # Thu Jan 01 1970 00:01:40 -0000
+    assert_equal "6wc2", Lexicoid.from(10000.0)         # Thu Jan 01 1970 02:46:40 -0000
+    assert_equal "2ykm2", Lexicoid.from(500000.0)       # Tue Jan 06 1970 18:53:20 -0000
+    assert_equal "5bse2", Lexicoid.from(1700000.0)      # Tue Jan 20 1970 16:13:20 -0000
+    assert_equal "2apny22", Lexicoid.from(28000000.0)   # Sat Nov 21 1970 01:46:40 -0000
+    assert_equal "6567f22", Lexicoid.from(550000000.0)  # Sat Jun 06 1987 17:46:40 -0000
+    assert_equal "flllz22", Lexicoid.from(1550000000.0) # Tue Feb 12 2019 19:33:20 -0000
+    assert_equal "gehebv2", Lexicoid.from(1654301676.0) # Sat Jun 04 2022 00:14:36 -0000
+    assert_equal "gei4p52", Lexicoid.from(1654401676.0) # Sun Jun 05 2022 04:01:16 -0000
+    assert_equal "gj7x3v2", Lexicoid.from(1674301676.0) # Sat Jan 21 2023 11:47:56 -0000
+    assert_equal "gj7x3vc", Lexicoid.from(1674301677.0) # Sat Jan 21 2023 11:47:57 -0000
+  end
+
+  def test_from_with_datetimes
+    assert_equal "22", Lexicoid.from(DateTime.parse("Thu Jan 01 1970 00:00:00 -0000"))
+    assert_equal "gk", Lexicoid.from(DateTime.parse("Thu Jan 01 1970 00:01:40 -0000"))
+    assert_equal "6wc2", Lexicoid.from(DateTime.parse("Thu Jan 01 1970 02:46:40 -0000"))
+    assert_equal "2ykm2", Lexicoid.from(DateTime.parse("Tue Jan 06 1970 18:53:20 -0000"))
+    assert_equal "5bse2", Lexicoid.from(DateTime.parse("Tue Jan 20 1970 16:13:20 -0000"))
+    assert_equal "2apny22", Lexicoid.from(DateTime.parse("Sat Nov 21 1970 01:46:40 -0000"))
+    assert_equal "6567f22", Lexicoid.from(DateTime.parse("Sat Jun 06 1987 17:46:40 -0000"))
+    assert_equal "flllz22", Lexicoid.from(DateTime.parse("Tue Feb 12 2019 19:33:20 -0000"))
+    assert_equal "gehebv2", Lexicoid.from(DateTime.parse("Sat Jun 04 2022 00:14:36 -0000"))
+    assert_equal "gei4p52", Lexicoid.from(DateTime.parse("Sun Jun 05 2022 04:01:16 -0000"))
+    assert_equal "gj7x3v2", Lexicoid.from(DateTime.parse("Sat Jan 21 2023 11:47:56 -0000"))
+    assert_equal "gj7x3vc", Lexicoid.from(DateTime.parse("Sat Jan 21 2023 11:47:57 -0000"))
+  end
+
+  def test_from_with_times
+    assert_equal "22", Lexicoid.from(Time.parse("Thu Jan 01 1970 00:00:00 -0000"))
+    assert_equal "gk", Lexicoid.from(Time.parse("Thu Jan 01 1970 00:01:40 -0000"))
+    assert_equal "6wc2", Lexicoid.from(Time.parse("Thu Jan 01 1970 02:46:40 -0000"))
+    assert_equal "2ykm2", Lexicoid.from(Time.parse("Tue Jan 06 1970 18:53:20 -0000"))
+    assert_equal "5bse2", Lexicoid.from(Time.parse("Tue Jan 20 1970 16:13:20 -0000"))
+    assert_equal "2apny22", Lexicoid.from(Time.parse("Sat Nov 21 1970 01:46:40 -0000"))
+    assert_equal "6567f22", Lexicoid.from(Time.parse("Sat Jun 06 1987 17:46:40 -0000"))
+    assert_equal "flllz22", Lexicoid.from(Time.parse("Tue Feb 12 2019 19:33:20 -0000"))
+    assert_equal "gehebv2", Lexicoid.from(Time.parse("Sat Jun 04 2022 00:14:36 -0000"))
+    assert_equal "gei4p52", Lexicoid.from(Time.parse("Sun Jun 05 2022 04:01:16 -0000"))
+    assert_equal "gj7x3v2", Lexicoid.from(Time.parse("Sat Jan 21 2023 11:47:56 -0000"))
+    assert_equal "gj7x3vc", Lexicoid.from(Time.parse("Sat Jan 21 2023 11:47:57 -0000"))
+  end
+
+  def test_from_with_times_with_zone
+    assert_equal "22", Lexicoid.from(Time.zone.parse("Thu Jan 01 1970 00:00:00 -0000"))
+    assert_equal "gk", Lexicoid.from(Time.zone.parse("Thu Jan 01 1970 00:01:40 -0000"))
+    assert_equal "6wc2", Lexicoid.from(Time.zone.parse("Thu Jan 01 1970 02:46:40 -0000"))
+    assert_equal "2ykm2", Lexicoid.from(Time.zone.parse("Tue Jan 06 1970 18:53:20 -0000"))
+    assert_equal "5bse2", Lexicoid.from(Time.zone.parse("Tue Jan 20 1970 16:13:20 -0000"))
+    assert_equal "2apny22", Lexicoid.from(Time.zone.parse("Sat Nov 21 1970 01:46:40 -0000"))
+    assert_equal "6567f22", Lexicoid.from(Time.zone.parse("Sat Jun 06 1987 17:46:40 -0000"))
+    assert_equal "flllz22", Lexicoid.from(Time.zone.parse("Tue Feb 12 2019 19:33:20 -0000"))
+    assert_equal "gehebv2", Lexicoid.from(Time.zone.parse("Sat Jun 04 2022 00:14:36 -0000"))
+    assert_equal "gei4p52", Lexicoid.from(Time.zone.parse("Sun Jun 05 2022 04:01:16 -0000"))
+    assert_equal "gj7x3v2", Lexicoid.from(Time.zone.parse("Sat Jan 21 2023 11:47:56 -0000"))
+    assert_equal "gj7x3vc", Lexicoid.from(Time.zone.parse("Sat Jan 21 2023 11:47:57 -0000"))
+  end
+
+  def test_from_raises_for_improper_arguments
+    ex = assert_raises(ArgumentError) { Lexicoid.from(Time.at(-1)) }
+    assert_match(/after/, ex.message)
+
+    ex = assert_raises(ArgumentError) { Lexicoid.from(DateTime.parse("Wed Dec 31 1969 23:59:59 -0000")) }
+    assert_match(/after/, ex.message)
+
+    ex = assert_raises(ArgumentError) { Lexicoid.from(1.day.before(Time.at(0))) }
+    assert_match(/after/, ex.message)
+
+    ex = assert_raises(ArgumentError) { Lexicoid.from(-1) }
+    assert_match(/non-negative/, ex.message)
+
+    ex = assert_raises(ArgumentError) { Lexicoid.from(-1.0) }
+    assert_match(/non-negative/, ex.message)
+
+    ex = assert_raises(ArgumentError) { Lexicoid.from("1234") }
+    assert_match(/one of/, ex.message)
+  end
+
+  def test_kernel_method_delegates_correctly
+    assert_equal Lexicoid(1234), Lexicoid.from(1234)
+    assert_raises(ArgumentError) { Lexicoid.from(-1) }
+  end
+
+  def test_now_uses_the_current_time
+    Time.stub :now, Time.at(1_678_943_067) do
+      assert_equal "gkdeaqs", Lexicoid.now
+    end
+  end
 end


### PR DESCRIPTION
Lexicoids are special cases of Base32-encoding for integers. These
integers correspond to timestamps, which naturally come from the Unix
epoch.

This change handles timestamps of many forms and converts them into
lexicoids appropriately.

The test suite conforms to the same list of tests from [the Rust
library][1] in addition to a few edge cases and a verification of one
from Brandur's blog.

[1]: https://github.com/lmammino/lexicoid/blob/9efe314998609a769aff405d16a0e4e95dab13de/src/lib.rs#L100-L111